### PR TITLE
#42: Remove useTheme/useStyles from EventTooltip

### DIFF
--- a/src/Marks.tsx
+++ b/src/Marks.tsx
@@ -6,7 +6,8 @@ import { Theme } from '@material-ui/core'
 import { EventComponentFactory, EventComponentRole, TimelineEvent } from './model'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import useTheme from '@material-ui/core/styles/useTheme'
-import { EventTooltip } from './tooltip'
+import { EventTooltip, TooltipClasses, useTooltipStyle } from './tooltip'
+import { useTimelineTheme } from './theme'
 
 const useStyles = makeStyles((theme: Theme) => ({
   eventBackground: {
@@ -54,7 +55,9 @@ export interface Props<EID, LID> {
  */
 export const Marks = <EID extends string, LID extends string>(props: Props<EID, LID>) => {
   const { events, height } = props
+  const timelineTheme = useTimelineTheme()
   const classes = useStyles()
+  const tooltipClasses = useTooltipStyle(timelineTheme.tooltip)
   const { eventComponent, timeScale, y } = props
 
   // shorter periods on top of longer ones
@@ -91,7 +94,7 @@ export const Marks = <EID extends string, LID extends string>(props: Props<EID, 
   const backgroundMarks = useMemo(
     () =>
       events.map((e: TimelineEvent<EID, LID>) => (
-        <InteractiveEventMark key={e.eventId} event={e} {...props}>
+        <InteractiveEventMark key={e.eventId} event={e} tooltipClasses={tooltipClasses} {...props}>
           {eventComponentFactory(e, 'background', timeScale, y)}
         </InteractiveEventMark>
       )),
@@ -104,7 +107,7 @@ export const Marks = <EID extends string, LID extends string>(props: Props<EID, 
         .filter((_) => true)
         .sort(sortByEventDuration)
         .map((e: TimelineEvent<EID, LID>) => (
-          <InteractiveEventMark key={e.eventId} event={e} {...props}>
+          <InteractiveEventMark key={e.eventId} event={e} tooltipClasses={tooltipClasses} {...props}>
             {eventComponentFactory(e, 'foreground', timeScale, y)}
           </InteractiveEventMark>
         )),
@@ -117,7 +120,7 @@ export const Marks = <EID extends string, LID extends string>(props: Props<EID, 
         .filter((e) => e.isSelected || e.isPinned)
         .sort(sortByEventDuration)
         .map((e: TimelineEvent<EID, LID>) => (
-          <InteractiveEventMark key={e.eventId} event={e} {...props}>
+          <InteractiveEventMark key={e.eventId} event={e} tooltipClasses={tooltipClasses} {...props}>
             {eventComponentFactory(e, 'foreground', timeScale, y)}
           </InteractiveEventMark>
         )),
@@ -140,6 +143,7 @@ interface InteractiveGroupProps<EID, LID> {
   onEventHover?: (eventId: EID) => void
   onEventUnhover?: (eventId: EID) => void
   onEventClick?: (eventId: EID) => void
+  tooltipClasses: TooltipClasses
   children: React.ReactNode
 }
 
@@ -150,6 +154,7 @@ const InteractiveEventMark = <EID, LID>({
   onEventClick = noOp,
   onEventHover = noOp,
   onEventUnhover = noOp,
+  tooltipClasses,
   children,
 }: InteractiveGroupProps<EID, LID>) => {
   const eventId = event.eventId
@@ -174,7 +179,14 @@ const InteractiveEventMark = <EID, LID>({
     >
       <g ref={triggerRef}>{children}</g>
       {event.tooltip ? (
-        <EventTooltip type={tooltipType} y={y} parentWidth={parentWidth} triggerRef={triggerRef} text={event.tooltip} />
+        <EventTooltip
+          type={tooltipType}
+          y={y}
+          parentWidth={parentWidth}
+          triggerRef={triggerRef}
+          text={event.tooltip}
+          classes={tooltipClasses}
+        />
       ) : (
         <g />
       )}

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -1,30 +1,8 @@
-import makeStyles from '@material-ui/core/styles/makeStyles'
-import { Theme } from '@material-ui/core'
 import * as React from 'react'
 import TextSize from '../TextSize'
 import { Tooltip } from 'react-svg-tooltip'
 import { scaleLinear } from 'd3-scale'
-import { TooltipTheme } from '../theme/model'
-import { useTimelineTheme } from '../theme'
-
-const TOOLTIP_FONT_SIZE = 14
-
-const useTooltipStyle = makeStyles((theme: Theme) => ({
-  svg: {
-    textAlign: 'left',
-  },
-  background: (tooltipTheme: TooltipTheme) => ({
-    fill: tooltipTheme.backgroundColor,
-    strokeWidth: 0,
-  }),
-  text: {
-    fill: 'white',
-    dominantBaseline: 'middle',
-    textAnchor: 'middle',
-    fontFamily: theme.typography.caption.fontFamily,
-    fontSize: TOOLTIP_FONT_SIZE,
-  },
-}))
+import { TooltipClasses, TOOLTIP_FONT_SIZE } from './useTooltipStyle'
 
 interface Props {
   readonly type: { singleEventX: number } | 'period'
@@ -32,12 +10,10 @@ interface Props {
   readonly parentWidth: number
   readonly text: string
   readonly triggerRef: React.RefObject<SVGElement>
+  readonly classes: TooltipClasses
 }
 
-export const EventTooltip = ({ type, y, parentWidth, text, triggerRef }: Props) => {
-  const tooltipTheme = useTimelineTheme().tooltip
-  const classes = useTooltipStyle(tooltipTheme)
-
+export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes }: Props) => {
   const { textLines, tooltipWidth, tooltipHeight, baseHeight } = getTooltipDimensions(text)
 
   return (

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -1,1 +1,2 @@
 export { EventTooltip } from './EventTooltip'
+export * from './useTooltipStyle'

--- a/src/tooltip/useTooltipStyle.ts
+++ b/src/tooltip/useTooltipStyle.ts
@@ -1,0 +1,25 @@
+import makeStyles from '@material-ui/core/styles/makeStyles'
+import { Theme } from '@material-ui/core'
+import { TooltipTheme } from '../theme/model'
+import { ClassNameMap } from '@material-ui/styles'
+
+export type TooltipClasses = ClassNameMap<'background' | 'text' | 'svg'>
+
+export const TOOLTIP_FONT_SIZE = 14
+
+export const useTooltipStyle = makeStyles((theme: Theme) => ({
+  svg: {
+    textAlign: 'left',
+  },
+  background: (tooltipTheme: TooltipTheme) => ({
+    fill: tooltipTheme.backgroundColor,
+    strokeWidth: 0,
+  }),
+  text: {
+    fill: 'white',
+    dominantBaseline: 'middle',
+    textAnchor: 'middle',
+    fontFamily: theme.typography.caption.fontFamily,
+    fontSize: TOOLTIP_FONT_SIZE,
+  },
+}))


### PR DESCRIPTION
This fix avoids generating styles for each individual EventTooltip as this is time consuming and thus affecting rendering performance for large datasets significantly.