### PR TITLE
Correct yarn installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A React event timeline component based on SVG.
 
 ## Installation
 
-`yarn install react-svg-timeline`
+`yarn add react-svg-timeline`
 
 or
 


### PR DESCRIPTION
Yarn no longer uses `install` as the subcommand for adding packages. It switched to `add`.

```
$ yarn install react-svg-timeline
yarn install v1.22.10
error `install` has been replaced with `add` to add new dependencies. Run "yarn add yarn install react-svg-timeline" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```