### PR TITLE
fix TS warning for es6 spread

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["src"],
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,


### PR DESCRIPTION
Updates to include spread operator for lines like https://github.com/netzwerg/react-svg-timeline/blob/main/src/hooks/useTimeline.ts#L11